### PR TITLE
Defer ACF-dependent configuration reads

### DIFF
--- a/source/php/App.php
+++ b/source/php/App.php
@@ -8,20 +8,11 @@ class App
 {
     public function __construct()
     {
-        //Warn for missing api-keys, end execution
-        if (!Options::isConfigured()) {
-            add_action('admin_notices', array($this, 'displayAdminNotice'));
-        }
-
         //Config page
         new \AlgoliaIndex\Admin\Settings();
 
-        if (Options::isConfigured()) {
-            //Run plugin
-            new \AlgoliaIndex\Index();
-            new \AlgoliaIndex\Search();
-            new \AlgoliaIndex\Facetting();
-        }
+        // Defer ACF-dependent configuration reads until ACF is initialized.
+        add_action('acf/init', array($this, 'initializeConfiguredFeatures'), 20);
 
         //Admin pages
         new \AlgoliaIndex\Admin\Post();
@@ -30,6 +21,23 @@ class App
         if (defined('WP_CLI') && WP_CLI == true) {
             new \AlgoliaIndex\Bulk();
         }
+    }
+
+    /**
+     * Initialize features that depend on configuration stored in ACF.
+     *
+     * @return void
+     */
+    public function initializeConfiguredFeatures()
+    {
+        if (!Options::isConfigured()) {
+            add_action('admin_notices', array($this, 'displayAdminNotice'));
+            return;
+        }
+
+        new \AlgoliaIndex\Index();
+        new \AlgoliaIndex\Search();
+        new \AlgoliaIndex\Facetting();
     }
 
     /**


### PR DESCRIPTION
## Summary

- keep admin and post hooks registered during normal plugin construction
- defer only ACF-dependent configuration reads and search bootstrap until `acf/init`
- run the deferred bootstrap at priority 20, after the settings page callback registered at priority 10

## Verification

- `php -l source/php/App.php`
- an isolated bootstrap harness reproduces the early ACF read before the change
- the same harness verifies settings/post hook registration before `acf/init`, settings-page registration at priority 10, and configured feature initialization at priority 20 after the change

`composer validate --strict --no-check-lock` reports only the repository's existing exact-version warning for `algolia/algoliasearch-client-php`.
